### PR TITLE
WIP - Refactor tiplist layout and childrens removing CSS.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,7 +4,7 @@ import { ThemeProvider } from "@material-ui/core";
 // Tip data from mocky API: "http://www.mocky.io/v2/5e2d10a43000005c00e77c8b"
 import tipStates from "lib/mockData";
 // Style
-import "./App.scss";
+//import "./App.scss";
 import { theme } from "styles/theme";
 // Components
 import TipList from "components/TipList/TipList";
@@ -12,7 +12,7 @@ import TipsLayout from "components/TipsLayout/TipsLayout";
 
 const App = () => (
   <ThemeProvider theme={theme}>
-    <div className="App">
+    <div>
       <TipsLayout sectionTitle="Fitness Tips">
         <TipList tipStates={tipStates} />
       </TipsLayout>

--- a/src/App.js
+++ b/src/App.js
@@ -12,11 +12,9 @@ import TipsLayout from "components/TipsLayout/TipsLayout";
 
 const App = () => (
   <ThemeProvider theme={theme}>
-    <div>
-      <TipsLayout sectionTitle="Fitness Tips">
-        <TipList tipStates={tipStates} />
-      </TipsLayout>
-    </div>
+    <TipsLayout sectionTitle="Fitness Tips">
+      <TipList tipStates={tipStates} />
+    </TipsLayout>
   </ThemeProvider>
 );
 

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1,20 +1,20 @@
 import React from "react";
 //style
-import "./Header.sass";
+//import "./Header.sass";
 //components
-import { Typography } from "@material-ui/core";
+import { Typography, Box } from "@material-ui/core";
 import SearchBar from "components/SearchBar/SearchBar";
 
 const Header = ({ isSearchBarVisible, sectionTitle }) => (
-  <>
-    <Typography align="center" className="mainTitle" color="primary" variant="h1">
+  <Box display="flex" flexDirection="column" justifyContent="center" m={2}>
+    <Typography align="center" variant="h3">
       Healthy App
     </Typography>
     {isSearchBarVisible && <SearchBar />}
-    <Typography align="center" className="mainTitle" color="secondary" variant="h3">
+    <Typography align="center" m={2} variant="h5">
       {sectionTitle}
     </Typography>
-  </>
+  </Box>
 );
 
 export default Header;

--- a/src/components/SearchBar/SearchBar.jsx
+++ b/src/components/SearchBar/SearchBar.jsx
@@ -1,14 +1,12 @@
 import React from "react";
 import SearchIcon from "@material-ui/icons/Search";
 import { TextField } from "@material-ui/core";
-import "./SearchBar.sass";
+//import "./SearchBar.sass";
 
 const SearchBar = () => (
   <TextField
-    color="primary"
-    id="standard-search"
     InputProps={{
-      endAdornment: <SearchIcon className="searchIco" />,
+      endAdornment: <SearchIcon />,
     }}
     label="Buscar"
     type="search"

--- a/src/components/Tip/Tip.jsx
+++ b/src/components/Tip/Tip.jsx
@@ -1,17 +1,17 @@
 import React from "react";
 // Hooks
-import { useTheme } from "@material-ui/core/styles";
+//import { useTheme } from "@material-ui/core/styles";
 // Styles
-import "components/Tip/Tip.scss";
+//import "components/Tip/Tip.scss";
 // Components
 import { Avatar, Card, CardContent, CardMedia, Typography } from "@material-ui/core";
 
 const Tip = ({ avatar, media, title }) => (
-  <Card square className="card" elevation={0}>
-    <Avatar alt="" src={avatar} style={useTheme().avatar} />
-    <CardMedia className="media" component="img" image={media} title="" />
-    <CardContent className="cardText">
-      <Typography className="title" component="h2" variant="subtitle2">
+  <Card square elevation={0}>
+    <Avatar alt="" src={avatar} />
+    <CardMedia component="img" image={media} title="" />
+    <CardContent>
+      <Typography component="h2" variant="subtitle2">
         {title}
       </Typography>
     </CardContent>

--- a/src/components/Tip/Tip.jsx
+++ b/src/components/Tip/Tip.jsx
@@ -4,17 +4,12 @@ import React from "react";
 // Styles
 //import "components/Tip/Tip.scss";
 // Components
-import { Avatar, Card, CardContent, CardMedia, Typography } from "@material-ui/core";
+import { Card, CardMedia, Typography } from "@material-ui/core";
 
-const Tip = ({ avatar, media, title }) => (
+const Tip = ({ media, title }) => (
   <Card square elevation={0}>
-    <Avatar alt="" src={avatar} />
-    <CardMedia component="img" image={media} title="" />
-    <CardContent>
-      <Typography component="h2" variant="subtitle2">
-        {title}
-      </Typography>
-    </CardContent>
+    <CardMedia component="img" image={media} />
+    <Typography>{title}</Typography>
   </Card>
 );
 

--- a/src/components/TipList/TipList.jsx
+++ b/src/components/TipList/TipList.jsx
@@ -1,11 +1,11 @@
 import React from "react";
 // Styles
-import "components/TipList/TipList.scss";
+//import "components/TipList/TipList.scss";
 // Components
 import Tip from "components/Tip/Tip";
 
 const TipList = ({ tipStates }) => (
-  <div className="grid-container">
+  <div>
     {tipStates.map(({ avatar, media, title, id }, index) => (
       <div key={id} className={`card card-${index}`}>
         <Tip avatar={avatar} media={media} title={title} />

--- a/src/components/TipList/TipList.jsx
+++ b/src/components/TipList/TipList.jsx
@@ -2,16 +2,30 @@ import React from "react";
 // Styles
 //import "components/TipList/TipList.scss";
 // Components
+import { Avatar, Box, IconButton, GridList, GridListTile, GridListTileBar } from "@material-ui/core";
 import Tip from "components/Tip/Tip";
 
 const TipList = ({ tipStates }) => (
-  <div>
-    {tipStates.map(({ avatar, media, title, id }, index) => (
-      <div key={id} className={`card card-${index}`}>
-        <Tip avatar={avatar} media={media} title={title} />
-      </div>
-    ))}
-  </div>
+  <Box mb={12}>
+    <GridList cellHeight="auto">
+      {tipStates.map(({ avatar, media, title, id }) => (
+        <GridListTile key={id} cols={1} rows={1} spacing={1}>
+          <GridListTileBar
+            actionIcon={
+              <IconButton>
+                <Avatar alt="" src={avatar} />
+              </IconButton>
+            }
+            actionPosition="left"
+            color="primary"
+            style={{ background: "none" }}
+            titlePosition="top"
+          />
+          <Tip media={media} title={title} />
+        </GridListTile>
+      ))}
+    </GridList>
+  </Box>
 );
 
 export default TipList;

--- a/src/components/TipsLayout/TipsLayout.jsx
+++ b/src/components/TipsLayout/TipsLayout.jsx
@@ -9,9 +9,9 @@ import BottomNavbar from "components/BottomNavbar/BottomNavbar";
 
 const TipsLayout = ({ isSearchBarVisible = true, children, sectionTitle }) => {
   return (
-    <Container className="container" color="primary-dark">
+    <Container disableGutters maxWidth="md">
       <Header isSearchBarVisible={isSearchBarVisible} sectionTitle={sectionTitle} />
-      <Container className="content">{children}</Container>
+      {children}
       <BottomNavbar />
     </Container>
   );

--- a/src/components/TipsLayout/TipsLayout.jsx
+++ b/src/components/TipsLayout/TipsLayout.jsx
@@ -1,20 +1,17 @@
 import React from "react";
 //style
-import { useTheme } from "@material-ui/core/styles";
-import "./TipsLayout.sass";
+//import { useTheme } from "@material-ui/core/styles";
+//import "./TipsLayout.sass";
 //components
 import { Container } from "@material-ui/core";
 import Header from "components/Header/Header";
 import BottomNavbar from "components/BottomNavbar/BottomNavbar";
 
 const TipsLayout = ({ isSearchBarVisible = true, children, sectionTitle }) => {
-  const theme = useTheme();
   return (
     <Container className="container" color="primary-dark">
       <Header isSearchBarVisible={isSearchBarVisible} sectionTitle={sectionTitle} />
-      <Container className="content" style={theme.reset}>
-        {children}
-      </Container>
+      <Container className="content">{children}</Container>
       <BottomNavbar />
     </Container>
   );

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -13,8 +13,4 @@ export const theme = createMuiTheme({
     contrastThreshold: 3,
     tonalOffset: 0.2,
   },
-  reset: {
-    padding: 0,
-    margin: 0,
-  },
 });


### PR DESCRIPTION
I managed to remove almost all css. I still need to go over the Bottom Nav Bar. There is a margin bottom on the main layout to compensate the Nav that will need to be removed.
Also the GridListTileBar Material Component in the TipList has a background color that I could not find out how to remove without resorting to a style override with: "style={{ background: "none" }}" as a prop.
No masonry layout yet.